### PR TITLE
Fixes #1 heap exhaustion on windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,11 +43,12 @@ internals.isFile = function (filePath) {
 
 internals.dirPaths = function (directory, filename) {
   const filePaths = [];
+  const pathRoot = Path.parse(directory).root;
 
   do {
     filePaths.push(Path.join(directory, filename));
     directory = Path.dirname(directory);
-  } while (directory !== Path.sep);
+  } while (directory !== pathRoot);
 
   return filePaths;
 };


### PR DESCRIPTION
Windows paths do not start with the path separator (`\\`) therefore the loop continues to try and match `C:\\` to `\\`
