### PR TITLE
Default home to current dir instead of undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ internals.dirPaths = function (directory, filename) {
 
 
 internals.homePaths = function (filename) {
-  const home = process.env.USERPROFILE || process.env.HOME || "";
+  const home = process.env.USERPROFILE || process.env.HOME || '';
   return [
     Path.join(home, filename),
     Path.join(home, '.config', filename)

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ internals.dirPaths = function (directory, filename) {
 
 
 internals.homePaths = function (filename) {
-  const home = process.env.USERPROFILE || process.env.HOME;
+  const home = process.env.USERPROFILE || process.env.HOME || "";
   return [
     Path.join(home, filename),
     Path.join(home, '.config', filename)


### PR DESCRIPTION
Currently if process.env.USERPROFILE and process.env.HOME are undefined the function fails.
This can very well happen depending on the environment and should not be a cause for hard failure.
Defaulting to '', the current directory